### PR TITLE
Print error and close cleanly on unsupported year

### DIFF
--- a/habutax/__init__.py
+++ b/habutax/__init__.py
@@ -205,7 +205,13 @@ def main():
     # Solver argument setup
     solve_parser = subparsers.add_parser('solve', help='Solve taxes using HabuTax')
     solve_parser.add_argument('input_file', type=str, help='The file containing your input for the tax forms you are calculating.')
-    solve_parser.add_argument('--year', type=int, default=default_year, help=f'The tax year to use (default: {default_year})')
+    solve_parser.add_argument(
+        '--year',
+        choices=forms.available_forms.keys(),
+        type=int,
+        default=default_year,
+        help=f'The tax year to use (default: {default_year})'
+    )
     solve_parser.add_argument('--form', dest='forms', action='append', help='Which form(s) you want to calculate')
     solve_parser.add_argument('--prompt-missing', action='store_true', default=False, help='Interactively prompt for any missing input')
     solve_parser.add_argument('--writeback-input', action='store_true', default=False, help='Write any interactively-supplied input back to the config file when done (loses any comments/formatting present in file)')


### PR DESCRIPTION
The old behavior was to crash with a KeyError when the requested year is not a valid key in the available forms dictionary. This guards the dictionary access with a check to print out an error and exit with exit code 1 if the year is not in the dictionary.

Another way to handle the error would have been to default the available forms to an empty list, which results in the user getting a message that the requested form is not available. I thought that might be more confusing, and defers the error handling until later. I've heard it's good to detect and handle potential issues as early as possible.